### PR TITLE
Remove chrome-specific CSS loading code

### DIFF
--- a/src/collect.js
+++ b/src/collect.js
@@ -1,10 +1,3 @@
-$('head').append(
-    $('<link>')
-        .attr('rel', 'stylesheet')
-        .attr('type', 'text/css')
-        .attr('href', chrome.extension.getURL('css/sherd_styles.css'))
-);
-
 window.MediathreadCollect = {
     /* updated by /accounts/logged_in.js */
     'user_status': {


### PR DESCRIPTION
CSS loading will have to be handled in the extensions themselves.