### PR TITLE
Only test on node 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4.2"
-  - "5.1"
+  - "5"
 script:
   - make test


### PR DESCRIPTION
I don't think there is much point in testing this library in multiple version of node.js, since
it's only ever running in node.js during testing.