### PR TITLE
remove unnecessary hosthandler override

### DIFF
--- a/src/collect.js
+++ b/src/collect.js
@@ -26,7 +26,6 @@ window.MediathreadCollect = {
     'assethandler': assetHandler,
     'gethosthandler': function() {
         var hosthandler = MediathreadCollect.hosthandler;
-        hosthandler['mcah.columbia.edu'] = hosthandler['learn.columbia.edu'];
         for (var host in hosthandler) {
             if (new RegExp(host + '$').test(
                 location.hostname.replace('.ezproxy.cul.columbia.edu', '')


### PR DESCRIPTION
There's no longer a custom learn.columbia.edu hosthandler, so we can remove this line.